### PR TITLE
Move clients to Postgres database

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -43,5 +43,12 @@ hhs-debug() {
     popd > /dev/null
 }
 
+echo "    * Use 'hhs-generate-clients' to run the app with remote debugging enabled"
+hhs-generate-clients() {
+    pushd /src > /dev/null
+    node generate-clients.js
+    popd > /dev/null
+}
+
 
 echo

--- a/.studiorc
+++ b/.studiorc
@@ -50,5 +50,12 @@ hhs-generate-clients() {
     popd > /dev/null
 }
 
+echo "    * Use 'hhs-load-clients' to populate postgres table from static/client-enrollments.json"
+hhs-load-clients() {
+    pushd /src > /dev/null
+    node load-clients.js
+    popd > /dev/null
+}
+
 
 echo

--- a/.studiorc
+++ b/.studiorc
@@ -36,8 +36,6 @@ hhs-server() {
 
 echo "    * Use 'hhs-debug' to run the app with remote debugging enabled"
 hhs-debug() {
-    hhs-update
-
     pushd /src > /dev/null
     node --inspect-brk=0.0.0.0:9229 index.js
     popd > /dev/null

--- a/.studiorc
+++ b/.studiorc
@@ -9,7 +9,7 @@ echo "--> Setting up OpenHousing project..."
 
 echo "    * Use 'hhs-bootstrap' to install/updats all dependencies"
 hhs-bootstrap() {
-    echo "    Installing dependencies"
+    echo "    Installing habitat studio dependencies"
     hab pkg install -b core/node
 
     echo "    Running: script/bootstrap"
@@ -24,6 +24,9 @@ hhs-setup() {
 
 echo "    * Use 'hhs-update' to update project to run at its current version"
 hhs-update() {
+    echo "    Installing/updating habitat studio dependencies"
+    hab pkg install -b core/node
+
     echo "    Running: script/update"
     /src/script/update
 }

--- a/.studiorc
+++ b/.studiorc
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+
+export DEBUG=1
+
+
+echo
+echo "--> Setting up OpenHousing project..."
+
+echo "    * Use 'hhs-bootstrap' to install/updats all dependencies"
+hhs-bootstrap() {
+    echo "    Installing dependencies"
+    hab pkg install -b core/node
+
+    echo "    Running: script/bootstrap"
+    /src/script/bootstrap
+}
+
+echo "    * Use 'hhs-setup' to set up project to be run for the first time"
+hhs-setup() {
+    echo "    Running: script/setup"
+    /src/script/setup
+}
+
+echo "    * Use 'hhs-update' to update project to run at its current version"
+hhs-update() {
+    echo "    Running: script/update"
+    /src/script/update
+}
+
+echo "    * Use 'hhs-server' to start the app"
+hhs-server() {
+    echo "    Running: script/server"
+    /src/script/server
+}
+
+echo "    * Use 'hhs-debug' to run the app with remote debugging enabled"
+hhs-debug() {
+    hhs-update
+
+    pushd /src > /dev/null
+    node --inspect-brk=0.0.0.0:9229 index.js
+    popd > /dev/null
+}
+
+
+echo

--- a/.studiorc
+++ b/.studiorc
@@ -14,6 +14,16 @@ hhs-bootstrap() {
 
     echo "    Running: script/bootstrap"
     /src/script/bootstrap
+
+    echo "    Patching shebang lines in node_modules/.bin…"
+    NODE_PREFIX="$(hab pkg path core/node)"
+
+    grep -nlI '^\#\!/usr/bin/env node' ./node_modules/.bin/* | while read -r target; do
+        echo "$target"
+        sed -e "s#\#\!/usr/bin/env node#\#\!${NODE_PREFIX}/bin/node#" --in-place --follow-symlinks "$target"
+    done
+echo
+
 }
 
 echo "    * Use 'hhs-setup' to set up project to be run for the first time"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,17 @@
             "skipFiles": [
                 "<node_internals>/**"
             ]
+        },
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach to Remote",
+            "address": "127.0.0.1",
+            "port": 9229,
+            "localRoot": "${workspaceFolder}",
+            "remoteRoot": "/src",
+            "protocol": "inspector",
+            "restart": true
         }
     ]
 }

--- a/api.http
+++ b/api.http
@@ -16,3 +16,14 @@ GET {{host}}/auth/login
 
 ### Logout
 GET {{host}}/auth/logout
+
+
+### Manual developer login
+# hijack koa:* cookie values from a browser session and use this to save cookies
+POST {{host}}/auth/manual
+Content-Type: application/json
+
+{
+    "koa:sess": "COPY_FROM_BROWSER",
+    "koa:sess.sig": "COPY_FROM_BROWSER"
+}

--- a/api.http
+++ b/api.http
@@ -27,3 +27,15 @@ Content-Type: application/json
     "koa:sess": "COPY_FROM_BROWSER",
     "koa:sess.sig": "COPY_FROM_BROWSER"
 }
+
+
+### Get all clients
+GET {{host}}/api/clients
+
+
+### Get page 1 of clients
+GET {{host}}/api/clients?limit=25
+
+
+### Get page 2 of clients
+GET {{host}}/api/clients?limit=25&offset=25

--- a/db/client.js
+++ b/db/client.js
@@ -7,8 +7,8 @@ module.exports = (sequelize, DataTypes) => {
             type: DataTypes.INTEGER,
             primaryKey: true
         },
-        dedup_client_id: {
-            type: DataTypes.STRING,
+        cj_id: {
+            type: DataTypes.INTEGER,
             unique: true
         },
         first_name: {

--- a/db/client.js
+++ b/db/client.js
@@ -1,0 +1,102 @@
+'use strict';
+
+
+module.exports = (sequelize, DataTypes) => {
+    const Client = sequelize.define('Client', {
+        id: {
+            type: DataTypes.INTEGER,
+            primaryKey: true
+        },
+        dedup_client_id: {
+            type: DataTypes.STRING,
+            unique: true
+        },
+        first_name: {
+            type: DataTypes.STRING,
+            allowNull: false,
+            validate: {
+                notNull: {
+                    msg: 'Please provide client\'s first name',
+                },
+                len: {
+                    args: 1,
+                    msg: 'First Name must be at least 1 characters in length'
+                }
+            }
+        },
+        last_name: {
+            type: DataTypes.STRING,
+            allowNull: false,
+            validate: {
+                notNull: {
+                    msg: 'Please provide client\'s last name',
+                },
+                len: {
+                    args: 1,
+                    msg: 'Name must be at least 1 characters in length'
+                }
+            }
+        },
+        chronic_status: DataTypes.BOOLEAN,
+        currently_homeless_shelter: DataTypes.BOOLEAN,
+        currently_incarcerated: DataTypes.BOOLEAN,
+        disabled_status: DataTypes.BOOLEAN,
+        family_status: DataTypes.BOOLEAN,
+        history_unsheltered: DataTypes.BOOLEAN,
+        jail_release_date: {
+            type: DataTypes.DATEONLY,
+            allowNull: true
+        },
+        disabling_condition: DataTypes.BOOLEAN,
+
+        // TODO: use enum?
+        user_type_hmis: DataTypes.INTEGER,
+        user_type_cj: DataTypes.INTEGER,
+
+        veteran_status: DataTypes.BOOLEAN,
+        vi_spdat: {
+            type: DataTypes.INTEGER,
+            allowNull: true
+        },
+        active_ces: DataTypes.BOOLEAN,
+        assigned_navigator: DataTypes.BOOLEAN,
+        currently_homeless_program: DataTypes.BOOLEAN,
+        homeless_history: DataTypes.DECIMAL(2, 1),
+        housing_assessment_completed: DataTypes.BOOLEAN,
+        housing_navigator: {
+            type: DataTypes.STRING,
+            allowNull: true
+        },
+        jail_facility_name: {
+            type: DataTypes.STRING,
+            allowNull: true
+        },
+        match_initiation_completed: {
+            type: DataTypes.BOOLEAN,
+            allowNull: true
+        },
+        matched_psh_rrh: DataTypes.BOOLEAN,
+        recommended_intervention: {
+            type: DataTypes.STRING,
+            allowNull: true
+        },
+        year_last_cj_interaction: {
+            type: DataTypes.INTEGER,
+            allowNull: true
+        },
+        dob: {
+            type: DataTypes.DATEONLY,
+            allowNull: true
+        },
+        vi_spdat_assessed_date: {
+            type: DataTypes.DATEONLY,
+            allowNull: true
+        }
+    }, {
+        timestamps: true,
+        paranoid: true,
+        underscored: true
+    });
+
+    return Client;
+};

--- a/db/client.js
+++ b/db/client.js
@@ -9,7 +9,8 @@ module.exports = (sequelize, DataTypes) => {
         },
         cj_id: {
             type: DataTypes.INTEGER,
-            unique: true
+            // Removed this contraint to allow production data to be imported - KBC
+            unique: false
         },
         first_name: {
             type: DataTypes.STRING,

--- a/db/index.js
+++ b/db/index.js
@@ -1,0 +1,49 @@
+'use strict';
+
+// ensure env is complete
+if (!process.env.POSTGRES_URI) {
+    throw new Error("POSTGRES_URI required in env");
+}
+
+
+// connect to Postgres
+const Sequelize = require('sequelize');
+const db = {
+    sequelize: new Sequelize(process.env.POSTGRES_URI)
+};
+
+
+// load all models in directory
+const fs = require('fs');
+const path = require('path');
+const basename = path.basename(__filename);
+
+fs
+    .readdirSync(__dirname)
+    .filter(file => {
+        return (file.indexOf('.') !== 0) && (file !== basename) && (file.slice(-3) === '.js');
+    })
+    .forEach(file => {
+        const model = db.sequelize.import(path.join(__dirname, file));
+        db[model.name] = model;
+    });
+
+Object.keys(db).forEach(modelName => {
+    if (db[modelName].associate) {
+        db[modelName].associate(db);
+    }
+});
+
+
+/**
+ * Monkey patch issue causing deprecation warning when customizing allowNull validation error
+ *
+ * See https://github.com/sequelize/sequelize/issues/1500
+ */
+Sequelize.Validator.notNull = function (item) {
+    return !this.isNull(item);
+};
+
+
+// export db object
+module.exports = db;

--- a/index.js
+++ b/index.js
@@ -101,7 +101,8 @@ app.use(router.routes());
 // load route bundles
 [
     './routes/auth',
-    './routes/dashboard'
+    './routes/dashboard',
+    './routes/clients'
 ].forEach(routeBundle => {
     require(routeBundle)({app, router});
 });

--- a/index.js
+++ b/index.js
@@ -81,6 +81,18 @@ app.use(async (ctx, next) => {
 });
 
 
+// setup relaying of draw parameter for DataTable, which it needs because it can't for some reason keep track of its requests and responses
+app.use(async (ctx, next) => {
+    await next();
+
+    const drawParam = parseInt(ctx.request.query.draw, 10);
+
+    if (drawParam && ctx.status == 200 && typeof ctx.body == 'object') {
+        ctx.body.draw = drawParam;
+    }
+});
+
+
 // setup view renderer
 const hbs = require('koa-hbs');
 

--- a/index.js
+++ b/index.js
@@ -55,6 +55,10 @@ app.use(require('koa-session')(app));
 app.passport = require('./passport/okta')({ app });
 
 
+// setup body parser middleware
+app.use(require('koa-bodyparser')());
+
+
 // setup authentication enforcement
 app.unauthenticatedRoutes = [];
 

--- a/load-clients.js
+++ b/load-clients.js
@@ -19,8 +19,8 @@ const db = require('./db');
 
     // write clients
     try {
-        await db.Client.bulkCreate(clients.map(client => {
-            client.id = client.hmisID;
+        insertedClients = await db.Client.bulkCreate(clients.map(client => {
+            client.id = client.sourceSystemId;
             client.cj_id = client.cjID;
             client.first_name = client.firstName;
             client.last_name = client.lastName;

--- a/load-clients.js
+++ b/load-clients.js
@@ -1,0 +1,36 @@
+'use strict';
+
+
+// load config from .env into process.env
+require('dotenv').config();
+
+
+// connect to database
+const db = require('./db');
+
+
+// read clients
+(async () => {
+    // load clients
+    const clients = JSON.parse(require('fs').readFileSync('./static/client-enrollments.json'));
+
+    // create table
+    await db.Client.sync({force: true});
+
+    // write clients
+    try {
+        await db.Client.bulkCreate(clients.map(client => {
+            client.id = client.hmisID;
+            client.dedup_client_id = client.dedupClientId;
+            client.first_name = client.firstName;
+            client.last_name = client.lastName;
+            client.disabling_condition = Boolean(client.disabling_condition);
+
+            return client;
+        }));
+    } catch (err) {
+        console.error('failed to bulk create clients:', err);
+    }
+
+    process.exit(0);
+})();

--- a/load-clients.js
+++ b/load-clients.js
@@ -11,6 +11,7 @@ const db = require('./db');
 
 // read clients
 (async () => {
+    let insertedClients = [];
     // load clients
     const clients = JSON.parse(require('fs').readFileSync('./static/client-enrollments.json'));
 
@@ -29,11 +30,11 @@ const db = require('./db');
             client.user_type_cj = client.bookingCount;
             client.currently_incarcerated = Boolean(client.currentlyInJail);
 
-            return client;
+        return client;
         }));
     } catch (err) {
         console.error('failed to bulk create clients:', err);
     }
-
+    console.log(`Done. Inserted ${insertedClients.length}.`);
     process.exit(0);
 })();

--- a/load-clients.js
+++ b/load-clients.js
@@ -21,7 +21,7 @@ const db = require('./db');
     try {
         await db.Client.bulkCreate(clients.map(client => {
             client.id = client.hmisID;
-            client.dedup_client_id = client.dedupClientId;
+            client.cj_id = client.cjID;
             client.first_name = client.firstName;
             client.last_name = client.lastName;
             client.disabling_condition = Boolean(client.disabling_condition);

--- a/load-clients.js
+++ b/load-clients.js
@@ -25,6 +25,9 @@ const db = require('./db');
             client.first_name = client.firstName;
             client.last_name = client.lastName;
             client.disabling_condition = Boolean(client.disabling_condition);
+            client.user_type_hmis = client.homelessHousingStatusCount;
+            client.user_type_cj = client.bookingCount;
+            client.currently_incarcerated = Boolean(client.currentlyInJail);
 
             return client;
         }));

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "express-session": "^1.15.5",
     "jsonfile": "^4.0.0",
     "koa": "^2.3.0",
+    "koa-bodyparser": "^4.2.0",
     "koa-hbs": "^1.0.0",
     "koa-json": "^2.0.2",
     "koa-passport": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "koa-router": "^7.2.1",
     "koa-session": "^5.5.0",
     "koa-static": "^4.0.1",
+    "moment": "^2.20.1",
     "node-cache": "^4.1.1",
     "node-minify": "^2.3.1",
     "node-storage": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "node-minify": "^2.3.1",
     "node-storage": "0.0.7",
     "passport-okta-oauth": "0.0.1",
+    "pg": "^6.4.2",
     "request": "^2.81.0",
-    "request-promise": "^4.2.2"
+    "request-promise": "^4.2.2",
+    "sequelize": "^4.31.2"
   }
 }

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -19,6 +19,7 @@ module.exports = ({
         };
     });
 
+
     // Handle login
     const loginUrl = `${path}/login`;
 
@@ -63,5 +64,22 @@ module.exports = ({
     router.get(logoutUrl, async ctx => {
         ctx.logout();
         ctx.redirect(`${process.env.OKTA_AUDIENCE}/login/signout?fromURI=${app.baseUrl}`);
+    });
+
+
+    // Handle manual auth for developers
+    const manualAuthUrl = `${path}/manual`;
+
+    app.unauthenticatedRoutes.push(manualAuthUrl);
+
+    router.post(manualAuthUrl, ctx => {
+        for (const key of Object.keys(ctx.request.body)) {
+            ctx.cookies.set(key, ctx.request.body[key]);
+        }
+
+        ctx.body = {
+            success: true,
+            cookies: ctx.request.body
+        };
     });
 };

--- a/routes/clients.js
+++ b/routes/clients.js
@@ -1,4 +1,6 @@
 const { Client } = require('../db');
+const Sequelize = require('sequelize');
+const Op = Sequelize.Op;
 
 module.exports = ({
     app, // Koa Server instance
@@ -8,10 +10,11 @@ module.exports = ({
 }) => {
     // Handle dashboard
     router.get(`/api${path}`, async function (ctx) {
-        const queryOptions = {};
+        const queryOptions = {where:{}};
 
         const limit = parseInt(ctx.request.query.limit, 10);
         const offset = parseInt(ctx.request.query.offset, 10);
+        const search = ctx.request.query.search;
         const order = ctx.request.query.order && ctx.request.query.order.split(',').map(field => field.split(':'));
 
         if (limit) {
@@ -20,6 +23,23 @@ module.exports = ({
 
         if (offset) {
             queryOptions.offset = offset;
+        }
+
+        if (search && search.length > 0) {
+            if (isNaN(search)) {
+                queryOptions.where[Op.or] = [{
+                    first_name: {[Op.iLike]: `%${search}%`}
+                }, {
+                    last_name: {[Op.iLike]: `%${search}%`}
+                }];
+            }
+            else {
+                // TODO Could be more optimal, breaks search index on integer -- KBC
+                queryOptions.where[Op.or] = [
+                    Sequelize.literal(`CAST("id" AS TEXT) like '%${search}%'`),
+                    Sequelize.literal(`CAST("cj_id" AS TEXT) like '%${search}%'`)
+                ];
+            }
         }
 
         if (order) {

--- a/routes/clients.js
+++ b/routes/clients.js
@@ -13,8 +13,8 @@ module.exports = ({
     router.get(`/api${path}`, async function (ctx) {
         const queryOptions = {where:{}};
 
-        const limit = parseInt(ctx.request.query.limit, 10);
-        const offset = parseInt(ctx.request.query.offset, 10);
+        const limit = parseInt(ctx.request.query.limit, 100);
+        const offset = parseInt(ctx.request.query.offset, 100);
         const search = ctx.request.query.search;
         const searchColumns = ctx.request.query.searchColumns && ctx.request.query.searchColumns.split(',').map(field => field.split(':'));
         const releaseDateStart = ctx.query.releaseDateStart;

--- a/routes/clients.js
+++ b/routes/clients.js
@@ -8,15 +8,11 @@ module.exports = ({
 }) => {
     // Handle dashboard
     router.get(`/api${path}`, async function (ctx) {
-        const queryOptions = {
-            order: [
-                ['created_at', 'DESC'],
-                ['id', 'DESC']
-            ]
-        };
+        const queryOptions = {};
 
         const limit = parseInt(ctx.request.query.limit, 10);
         const offset = parseInt(ctx.request.query.offset, 10);
+        const order = ctx.request.query.order && ctx.request.query.order.split(',').map(field => field.split(':'));
 
         if (limit) {
             queryOptions.limit = limit;
@@ -24,6 +20,27 @@ module.exports = ({
 
         if (offset) {
             queryOptions.offset = offset;
+        }
+
+        if (order) {
+            order.forEach(field => {
+                field[1] = field[1].toUpperCase();
+
+                if (!field[0] in Client.rawAttributes) {
+                    throw new Error('invalid field name: '+field[0]);
+                }
+
+                if (field[1] != 'ASC' && field[1] != 'DESC') {
+                    throw new Error('invalid field order direction: '+field[1]);
+                }
+            });
+
+            queryOptions.order = order;
+        } else {
+            queryOptions.order = [
+                ['created_at', 'DESC'],
+                ['id', 'DESC']
+            ];
         }
 
         const result = await Client.findAndCountAll(queryOptions);

--- a/routes/clients.js
+++ b/routes/clients.js
@@ -15,6 +15,7 @@ module.exports = ({
         const limit = parseInt(ctx.request.query.limit, 10);
         const offset = parseInt(ctx.request.query.offset, 10);
         const search = ctx.request.query.search;
+        const searchColumns = ctx.request.query.searchColumns && ctx.request.query.searchColumns.split(',').map(field => field.split(':'));
         const order = ctx.request.query.order && ctx.request.query.order.split(',').map(field => field.split(':'));
 
         if (limit) {
@@ -40,6 +41,12 @@ module.exports = ({
                     Sequelize.literal(`CAST("cj_id" AS TEXT) like '%${search}%'`)
                 ];
             }
+        }
+
+        if (searchColumns) {
+            searchColumns.forEach(field => {
+                queryOptions.where[field[0]] = field[1];
+            });
         }
 
         if (order) {

--- a/routes/clients.js
+++ b/routes/clients.js
@@ -1,0 +1,37 @@
+const { Client } = require('../db');
+
+module.exports = ({
+    app, // Koa Server instance
+    router, // router instance
+
+    path = '/clients'
+}) => {
+    // Handle dashboard
+    router.get(`/api${path}`, async function (ctx) {
+        const queryOptions = {
+            order: [
+                ['created_at', 'DESC'],
+                ['id', 'DESC']
+            ]
+        };
+
+        const limit = parseInt(ctx.request.query.limit, 10);
+        const offset = parseInt(ctx.request.query.offset, 10);
+
+        if (limit) {
+            queryOptions.limit = limit;
+        }
+
+        if (offset) {
+            queryOptions.offset = offset;
+        }
+
+        const result = await Client.findAndCountAll(queryOptions);
+
+        ctx.body = {
+            success: true,
+            data: result.rows,
+            total: result.count
+        };
+    });
+};

--- a/routes/clients.js
+++ b/routes/clients.js
@@ -58,7 +58,7 @@ module.exports = ({
 
         if (validReleaseStartDate) {
             queryOptions.where['jail_release_date'] = {
-                [Op.gt]: releaseDateStart
+                [Op.gte]: releaseDateStart
             };
         }
 

--- a/routes/clients.js
+++ b/routes/clients.js
@@ -19,6 +19,7 @@ module.exports = ({
         const searchColumns = ctx.request.query.searchColumns && ctx.request.query.searchColumns.split(',').map(field => field.split(':'));
         const releaseDateStart = ctx.query.releaseDateStart;
         const releaseDateEnd = ctx.query.releaseDateEnd;
+        const youthOnly = (ctx.query.youthOnly == 'true');
         const order = ctx.request.query.order && ctx.request.query.order.split(',').map(field => field.split(':'));
 
         if (limit) {
@@ -65,7 +66,11 @@ module.exports = ({
             if (!queryOptions.where['jail_release_date']) {
                 queryOptions.where['jail_release_date'] = {};
             }
-            queryOptions.where['jail_release_date'][Op.lt] = releaseDateEnd ;
+            queryOptions.where['jail_release_date'][Op.lte] = releaseDateEnd ;
+        }
+
+        if (youthOnly) {
+            queryOptions.where['dob'] = { [Op.gte]: moment().subtract(24, "years") };
         }
 
         if (order) {

--- a/routes/dashboard.js
+++ b/routes/dashboard.js
@@ -1,5 +1,3 @@
-require('dotenv').config();
-
 module.exports = ({
     app, // Koa Server instance
     router // router instance

--- a/sample.env
+++ b/sample.env
@@ -1,6 +1,8 @@
 VERBOSE="true"
 PORT="3000"
 
+POSTGRES_URI="postgres://user:pass@example.com:5432/dbname"
+
 OKTA_AUDIENCE="https://dev-877690.oktapreview.com"
 OKTA_CLIENTID="0oacetxok6YNOuZA70h7"
 OKTA_CLIENTSECRET=""

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -6,15 +6,3 @@ cd "$(dirname "$0")/.."
 
 echo "==> Installing node dependencies…"
 npm install
-
-
-echo "==> Patching shebang lines in node_modules/.bin…"
-
-NODE_PREFIX="$(hab pkg path core/node)"
-
-grep -nlI '^\#\!/usr/bin/env node' ./node_modules/.bin/* | while read -r target; do
-    echo "$target"
-    sed -e "s#\#\!/usr/bin/env node#\#\!${NODE_PREFIX}/bin/node#" --in-place --follow-symlinks "$target"
-done
-
-echo

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -6,3 +6,15 @@ cd "$(dirname "$0")/.."
 
 echo "==> Installing node dependencies…"
 npm install
+
+
+echo "==> Patching shebang lines in node_modules/.bin…"
+
+NODE_PREFIX="$(hab pkg path core/node)"
+
+grep -nlI '^\#\!/usr/bin/env node' ./node_modules/.bin/* | while read -r target; do
+    echo "$target"
+    sed -e "s#\#\!/usr/bin/env node#\#\!${NODE_PREFIX}/bin/node#" --in-place --follow-symlinks "$target"
+done
+
+echo

--- a/script/setup
+++ b/script/setup
@@ -7,6 +7,14 @@ cd "$(dirname "$0")/.."
 # ensure dependencies are all available
 script/bootstrap
 
+# ensure app needs bootstrapping
+if [ -f .env ]; then
+    echo
+    echo ".env already exists, and setup will overwrite it"
+    echo "Delete .env before re-running setup to confirm"
+    exit 1
+fi
+
 echo "==> Initializing .env…"
 cp -v sample.env .env
 

--- a/script/update
+++ b/script/update
@@ -7,4 +7,7 @@ cd "$(dirname "$0")/.."
 # ensure dependencies are all available
 script/bootstrap
 
+# build frontend
+node_modules/.bin/gulp run
+
 # TODO: any needed data migrations

--- a/src/js/filters.js
+++ b/src/js/filters.js
@@ -263,11 +263,18 @@ $(document).ready(function() {
         ajax: {
             url: '/api/clients',
             data: function (query) {
+                var searchColumns = $.map($.grep(query.columns, function(field) {
+                    return field.searchable && field.search.value !== '';  
+                }), function(field) {
+                    return field.data + ':' + field.search.value
+                }).join(',');
+
                 return {
                     draw: query.draw,
                     limit: query.length,
                     offset: query.start,
                     search: query.search.value,
+                    searchColumns: searchColumns,
                     order: $.isArray(query.order) ? $.map(query.order, function (field) {
                         return query.columns[field.column].data+':'+field.dir;
                     }).join(',') : null
@@ -324,22 +331,26 @@ $(document).ready(function() {
             {
                 data: 'id',
                 name: 'hmis_id',
-                title: 'HMIS'
+                title: 'HMIS',
+                searchable: false
             },
             {
                 data: 'cj_id',
                 name: 'cj_id',
-                title: 'CJMIS'
+                title: 'CJMIS',
+                searchable: false
             },
             {
                 data: 'first_name',
                 name: 'firstName',
-                title: 'First Name'
+                title: 'First Name',
+                searchable: false
             },
             {
                 data: 'last_name',
                 name: 'lastName',
-                title: 'Last Name'
+                title: 'Last Name',
+                searchable: false
             },
             {
                 data: 'dob',

--- a/src/js/filters.js
+++ b/src/js/filters.js
@@ -1,6 +1,5 @@
 /* requires:
     moment.min.js
-    sample-data.js
     enums.js
     presets.js
 */

--- a/src/js/filters.js
+++ b/src/js/filters.js
@@ -197,6 +197,7 @@ $(document).ready(function() {
         autoWidth: false,
         serverSide: true,
         processing: true,
+        iDisplayLength: 100,
         ajax: {
             url: '/api/clients',
             data: function (query) {

--- a/src/js/filters.js
+++ b/src/js/filters.js
@@ -259,7 +259,10 @@ $(document).ready(function() {
                 return {
                     draw: query.draw,
                     limit: query.length,
-                    offset: query.start
+                    offset: query.start,
+                    order: $.isArray(query.order) ? $.map(query.order, function (field) {
+                        return query.columns[field.column].data+':'+field.dir;
+                    }).join(',') : null
                 };
             },
             dataSrc: function (payload) {

--- a/src/js/filters.js
+++ b/src/js/filters.js
@@ -77,6 +77,13 @@ $(document).ready(function() {
         dt.draw();
     };
 
+    $('#q').on('keyup', function () {
+        console.log('search', this.value)
+        var dt = clientsDataTable.DataTable();
+
+        dt.search(this.value).draw();
+    });
+
     // DataTables
 
     var booleanIcon = function(data, type, full, meta) {
@@ -260,6 +267,7 @@ $(document).ready(function() {
                     draw: query.draw,
                     limit: query.length,
                     offset: query.start,
+                    search: query.search.value,
                     order: $.isArray(query.order) ? $.map(query.order, function (field) {
                         return query.columns[field.column].data+':'+field.dir;
                     }).join(',') : null

--- a/src/js/filters.js
+++ b/src/js/filters.js
@@ -319,8 +319,8 @@ $(document).ready(function() {
                 title: 'HMIS'
             },
             {
-                data: 'dedup_client_id',
-                name: 'cjmis_id',
+                data: 'cj_id',
+                name: 'cj_id',
                 title: 'CJMIS'
             },
             {

--- a/src/js/filters.js
+++ b/src/js/filters.js
@@ -251,10 +251,23 @@ $(document).ready(function() {
             $('[data-toggle="tooltip"]').tooltip();
         },
         autoWidth: false,
-        paging: false,
+        serverSide: true,
+        processing: true,
         ajax: {
-            url: '/client-enrollments',
-            dataSrc: ''
+            url: '/api/clients',
+            data: function (query) {
+                return {
+                    draw: query.draw,
+                    limit: query.length,
+                    offset: query.start
+                };
+            },
+            dataSrc: function (payload) {
+                // populated totals where DataTable expects them but provides no config to change
+                payload.recordsTotal = payload.total;
+                payload.recordsFiltered = payload.total;
+                return payload.data;
+            }
         },
         buttons: [
             {
@@ -298,22 +311,22 @@ $(document).ready(function() {
         ],
         columns: [
             {
-                data: 'hmisID',
+                data: 'id',
                 name: 'hmis_id',
                 title: 'HMIS'
             },
             {
-                data: 'cjID',
+                data: 'dedup_client_id',
                 name: 'cjmis_id',
                 title: 'CJMIS'
             },
             {
-                data: 'firstName',
+                data: 'first_name',
                 name: 'firstName',
                 title: 'First Name'
             },
             {
-                data: 'lastName',
+                data: 'last_name',
                 name: 'lastName',
                 title: 'Last Name'
             },

--- a/src/js/filters.js
+++ b/src/js/filters.js
@@ -158,36 +158,6 @@ $(document).ready(function() {
         clientsDataTable.DataTable().draw();
     });
 
-    // youth search filter
-    $.fn.dataTable.ext.search.push(
-        function(settings, data, dataIndex) {
-            var min = 18,
-                max = 24,
-                age = moment().diff(data[4], 'years'),
-                checkedVal = $('[name="youth_status"]:checked').val(),
-                isInRange = false;
-
-            if (checkedVal) {
-                if (( isNaN( min ) && isNaN( max ) ) ||
-                    ( isNaN( min ) && age <= max )   ||
-                    ( min <= age   && isNaN( max ) ) ||
-                    ( min <= age   && age <= max ) ) {
-
-                    isInRange = true;
-                }
-
-                if (checkedVal == "true") {
-                    return isInRange;
-                } else if (checkedVal == "false") {
-                    return !isInRange;
-                }
-            }
-
-            // no filter because no button checked
-            return true;
-        }
-    )
-
     // asc and desc sort functions to make sure non-integers are always ordered last
 
     $.fn.dataTable.ext.type.order['integer-asc'] = function(a, b) {
@@ -232,6 +202,7 @@ $(document).ready(function() {
             data: function (query) {
                 var releaseDateStart = $('[name=release_date_start]').val();
                 var releaseDateEnd = $('[name=release_date_end]').val();
+                var youthOnly = $('[name="youth_status"]:checked').val();
                 var searchColumns = $.map($.grep(query.columns, function(field) {
                     return field.searchable && field.search.value !== '';  
                 }), function(field) {
@@ -246,6 +217,7 @@ $(document).ready(function() {
                     searchColumns: searchColumns,
                     releaseDateStart: releaseDateStart,
                     releaseDateEnd: releaseDateEnd,
+                    youthOnly: youthOnly,
                     order: $.isArray(query.order) ? $.map(query.order, function (field) {
                         return query.columns[field.column].data+':'+field.dir;
                     }).join(',') : null

--- a/src/js/filters.js
+++ b/src/js/filters.js
@@ -248,10 +248,6 @@ $(document).ready(function() {
                 defaultContent: '&mdash;',
                 name: 'foo'
             },
-            // {
-            //     targets: [0, 1],
-            //     render: guidRenderer
-            // },
             {
                 targets: [6, 8],
                 type: 'integer',

--- a/src/js/filters.js
+++ b/src/js/filters.js
@@ -220,39 +220,6 @@ $(document).ready(function() {
         }
     }
 
-    var dateColumnIndex = 9;
-    // date range filtering
-    $.fn.dataTableExt.afnFiltering.push(
-        function( oSettings, aData, iDataIndex ) {
-            var start = $('[name=release_date_start]').val(),
-                end = $('[name=release_date_end]').val(),
-                rowDate = aData[dateColumnIndex] && new Date(aData[dateColumnIndex]) || null;
-
-            start = start.substring(6,10) + start.substring(0,2) + start.substring(3,5);
-            end = end.substring(6,10) + end.substring(0,2) + end.substring(3,5);
-
-            if (rowDate) {
-                date = `${rowDate.getFullYear()}`;
-                date += rowDate.getMonth() + 1 <= 9 ? `0${rowDate.getMonth()+1}` : `${rowDate.getMonth()+1}`;
-                date += rowDate.getDate() <= 0 ? `0${rowDate.getDate()}` : `${rowDate.getDate()}`;
-            }
-
-            if (start === "" && end === "" ) {
-                return true;
-            } else if (date === null) {
-                return false;
-            } else if (start <= date && end === "") {
-                return true;
-            } else if (end >= date && start === "") {
-                return true;
-            } else if (start <= date && end >= date) {
-                return true;
-            } else {
-                return false;
-            }
-        }
-    );
-
     clientsDataTable.DataTable({
         "fnDrawCallback": function() {
             $('[data-toggle="tooltip"]').tooltip();
@@ -263,6 +230,8 @@ $(document).ready(function() {
         ajax: {
             url: '/api/clients',
             data: function (query) {
+                var releaseDateStart = $('[name=release_date_start]').val();
+                var releaseDateEnd = $('[name=release_date_end]').val();
                 var searchColumns = $.map($.grep(query.columns, function(field) {
                     return field.searchable && field.search.value !== '';  
                 }), function(field) {
@@ -275,6 +244,8 @@ $(document).ready(function() {
                     offset: query.start,
                     search: query.search.value,
                     searchColumns: searchColumns,
+                    releaseDateStart: releaseDateStart,
+                    releaseDateEnd: releaseDateEnd,
                     order: $.isArray(query.order) ? $.map(query.order, function (field) {
                         return query.columns[field.column].data+':'+field.dir;
                     }).join(',') : null
@@ -396,7 +367,8 @@ $(document).ready(function() {
                 orderable: true,
                 render: {
                     display: dateRenderer
-                }
+                },
+                searchable: false
             },
             {
                 data: 'history_unsheltered',


### PR DESCRIPTION
## TODO

- [ ] Implement server-side filtering via the existing UI controls that worked for local filtering
  - See how ordering was implemented in 44b7560
  - Basic workflow:
    - Build query for server in `ajax.data` config function, all details on the filter state should be available already if they worked locally before in the `query` param provided to the data function
    - Validate and build query for sequelize in `/api/clients` route